### PR TITLE
Save gradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,12 @@ version = "0.5.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
-AdvancedMH = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InplaceOps = "505f98c9-085e-5b2c-8e89-488be7bf1f34"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 LogDensityProblemsAD = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
-MicroCanonicalHMC = "234d2aa0-2291-45f7-9047-6fa6f316b0a8"
-Pathfinder = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -21,17 +18,6 @@ SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-
-[weakdeps]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-
-[extensions]
-AdvancedHMCCUDAExt = "CUDA"
-AdvancedHMCMCMCChainsExt = "MCMCChains"
-AdvancedHMCOrdinaryDiffEqExt = "OrdinaryDiffEq"
 
 [compat]
 AbstractMCMC = "4.2"
@@ -51,7 +37,17 @@ StatsBase = "0.31, 0.32, 0.33, 0.34"
 StatsFuns = "0.8, 0.9, 1"
 julia = "1.6"
 
+[extensions]
+AdvancedHMCCUDAExt = "CUDA"
+AdvancedHMCMCMCChainsExt = "MCMCChains"
+AdvancedHMCOrdinaryDiffEqExt = "OrdinaryDiffEq"
+
 [extras]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+
+[weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,15 @@ version = "0.5.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
+AdvancedMH = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InplaceOps = "505f98c9-085e-5b2c-8e89-488be7bf1f34"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 LogDensityProblemsAD = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
+MicroCanonicalHMC = "234d2aa0-2291-45f7-9047-6fa6f316b0a8"
+Pathfinder = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -18,6 +21,17 @@ SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
+
+[weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+
+[extensions]
+AdvancedHMCCUDAExt = "CUDA"
+AdvancedHMCMCMCChainsExt = "MCMCChains"
+AdvancedHMCOrdinaryDiffEqExt = "OrdinaryDiffEq"
 
 [compat]
 AbstractMCMC = "4.2"
@@ -37,17 +51,7 @@ StatsBase = "0.31, 0.32, 0.33, 0.34"
 StatsFuns = "0.8, 0.9, 1"
 julia = "1.6"
 
-[extensions]
-AdvancedHMCCUDAExt = "CUDA"
-AdvancedHMCMCMCChainsExt = "MCMCChains"
-AdvancedHMCOrdinaryDiffEqExt = "OrdinaryDiffEq"
-
 [extras]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-
-[weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -163,6 +163,7 @@ function sample(
     adaptor::AbstractAdaptor = NoAdaptation(),
     n_adapts::Int = min(div(n_samples, 10), 1_000);
     drop_warmup = false,
+    keep_gradients = false,
     verbose::Bool = true,
     progress::Bool = false,
     (pm_next!)::Function = pm_next!,
@@ -225,7 +226,12 @@ function sample(
         # Store sample
         if !drop_warmup || i > n_adapts
             j = i - drop_warmup * n_adapts
-            θs[j], stats[j] = t.z.θ, tstat
+            if keep_gradients
+                sample = [t.z.θ; t.z.ℓπ]
+            else 
+                sample = t.z.θ
+            end
+            θs[j], stats[j] = sample, tstat
         end
     end
     # Report end of sampling

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -228,7 +228,7 @@ function sample(
             j = i - drop_warmup * n_adapts
             if keep_gradients
                 sample = [t.z.θ; t.z.ℓπ]
-            else 
+            else
                 sample = t.z.θ
             end
             θs[j], stats[j] = sample, tstat


### PR DESCRIPTION
### Description

This pull request modifies the `sample` function in `sampler.jl` to add a new keyword argument `keep_gradients` and update how samples are stored. Here are the changes:

- Added a new keyword argument `keep_gradients` with a default value of `false`.
- In the `sample` function, when storing a sample, it now checks whether `keep_gradients` is `true`. If `true`, it stores both the values of `t.z.θ` and `t.z.ℓπ`. If `false`, it only stores the value of `t.z.θ`.
- This change allows users to choose whether to include gradients (`ℓπ`) along with the samples (`θ`) when using the `sample` function.
- The `θs` and `stats` arrays are updated accordingly to store the new sample format.

No other changes are made in this pull request.